### PR TITLE
reset audioEngine on stop

### DIFF
--- a/stts/ios/stts/Sources/stts/stt/Stt.swift
+++ b/stts/ios/stts/Sources/stts/stt/Stt.swift
@@ -123,6 +123,7 @@ class Stt {
     
     audioEngine.stop()
     audioEngine.inputNode.removeTap(onBus: 0)
+    audioEngine.reset() // Adds extra stability
     
     recognitionTask?.cancel()
     recognitionTask = nil
@@ -230,6 +231,7 @@ class Stt {
     }
     
     let inputNode = audioEngine.inputNode
+    inputNode.removeTap(onBus: 0)
     let format = inputNode.inputFormat(forBus: 0)
     
     // feed our recognition task with request


### PR DESCRIPTION
When running on iOS, quite often the `.start(..)` call is failing.
This PR adds some small stability fixes. In my tests stability significantly improves with this change.