### PR TITLE
fix for SttRecognitionDarwinTaskHint toMap() conversion

### DIFF
--- a/stts_platform_interface/lib/src/stt/model/stt_recognition_options.dart
+++ b/stts_platform_interface/lib/src/stt/model/stt_recognition_options.dart
@@ -97,7 +97,7 @@ class SttRecognitionIosOptions {
   const SttRecognitionIosOptions({this.taskHint});
 
   Map<String, dynamic> toMap() {
-    return <String, dynamic>{'taskHint': taskHint};
+    return <String, dynamic>{'taskHint': taskHint?.name};
   }
 }
 
@@ -109,7 +109,7 @@ class SttRecognitionMacosOptions {
   const SttRecognitionMacosOptions({this.taskHint});
 
   Map<String, dynamic> toMap() {
-    return <String, dynamic>{'taskHint': taskHint};
+    return <String, dynamic>{'taskHint': taskHint?.name};
   }
 }
 


### PR DESCRIPTION
this PR fixes the following error when `SttRecognitionOptions` has ios and macos properties with `SttRecognitionDarwinTaskHint`:

```
## error Invalid argument: Instance of 'SttRecognitionDarwinTaskHint'
#0      StandardMessageCodec.writeValue (package:flutter/src/services/message_codecs.dart:464:7)
#1      StandardMessageCodec.writeValue.<anonymous closure> (package:flutter/src/services/message_codecs.dart:461:9)
#2      _LinkedHashMapMixin.forEach (dart:_compact_hash:772:13)
#3      StandardMessageCodec.writeValue (package:flutter/src/services/message_codecs.dart:459:13)
#4      StandardMessageCodec.writeValue.<anonymous closure> (package:flutter/src/services/message_codecs.dart:461:9)
#5      _LinkedHashMapMixin.forEach (dart:_compact_hash:772:13)
#6      StandardMessageCodec.writeValue (package:flutter/src/services/message_codecs.dart:459:13)
#7      StandardMessageCodec.writeValue.<anonymous closure> (package:flutter/src/services/message_codecs.dart:461:9)
#8      _LinkedHashMapMixin.forEach (dart:_compact_hash:772:13)
#9      StandardMessageCodec.writeValue (package:flutter/src/services/message_codecs.dart:459:13)
#10     StandardMethodCodec.encodeMethodCall (package:flutter/src/services/message_codecs.dart:600:18)
#11     MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:352:34)
#12     MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:539:12)
#13     SttMethodChannel.start (package:stts_platform_interface/src/stt/stt_method_channel_mixin.dart:53:27)
#14     Stt.start.<anonymous closure> (package:stts/src/stt.dart:28:33)
#15     Stt._safeCall (package:stts/src/stt.dart:46:22)
...
```